### PR TITLE
Fix EOY bug for Fiscal Year

### DIFF
--- a/server/src/services/payment-service.ts
+++ b/server/src/services/payment-service.ts
@@ -10,6 +10,7 @@ import { Donor } from '../models/Donor'
 import { Payment, PaymentSource } from '../models/Payment'
 import { PaypalPaymentSource } from '../models/PaypalPaymentSource'
 import { publishMessage } from '../pubsub/service'
+import { addTime, HOUR } from '../utils/datetime'
 import { logger } from '../utils/logging'
 
 export interface CreatePaymentParams {
@@ -139,6 +140,10 @@ function mapToDonation(
 ): Donation {
   const paymentDate = getPaymentDate(parameters.paymentDate)
 
+  // Adjusted for Pacific time in Canada. This is done to avoid having the wrong
+  // fiscal year on Dec 31st.
+  const adjustedPaymentDate = addTime(paymentDate, -8 * HOUR)
+
   const donation: Donation = {
     id: donationId,
     externalId: parameters.externalId || null,
@@ -147,7 +152,7 @@ function mapToDonation(
     emailReceipt: parameters.emailReceipt,
     fiscalYear: parameters.overrideFiscalYear
       ? parameters.overrideFiscalYear
-      : paymentDate.getFullYear(),
+      : adjustedPaymentDate.getFullYear(),
     type: parameters.type,
     payments: [mapToPayment(parameters)],
     correspondences: [],

--- a/server/src/services/pdf-service.ts
+++ b/server/src/services/pdf-service.ts
@@ -82,26 +82,29 @@ function mapDonationToReceiptInfo(
 async function buildReceiptNumber(donation: Donation): Promise<string> {
   const lastNamePart = donation.donor.lastName
     .replace(/\s/g, '')
-    .substr(0, 3)
+    .substring(0, 3)
     .padEnd(3, 'X')
     .toUpperCase()
 
   // Some donations are made by companies. This means they have do not have a first name.
   // In this case, we use the continuation of the last name field
   const firstName =
-    donation.donor.firstName || donation.donor.lastName.substr(3)
+    donation.donor.firstName || donation.donor.lastName.substring(3)
 
   const firstNamePart = firstName
     .replace(/\s/g, '')
-    .substr(0, 2)
+    .substring(0, 2)
     .padStart(2, 'X')
     .toUpperCase()
 
-  const randomChars = `${getRandomChar()}${getRandomChar()}${getRandomChar()}`
+  const randomChars = new Array(3)
+    .fill(null)
+    .map(() => getRandomChar())
+    .join('')
 
   const receiptNumberPrefix = `${lastNamePart}${firstNamePart}${donation.fiscalYear}-${randomChars}`
     .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[\u0300-\u036f\/]/g, '')
 
   const indices = donation.documents
     .filter((doc) => doc.id.startsWith(receiptNumberPrefix))

--- a/server/src/utils/datetime.ts
+++ b/server/src/utils/datetime.ts
@@ -1,0 +1,15 @@
+export const SECOND = 1000
+export const MINUTE = 60 * SECOND
+export const HOUR = 60 * MINUTE
+
+export function addTime(inputDate: Date, timeInMs: number): Date {
+  const ts = inputDate.getTime()
+
+  if (Number.isNaN(ts)) {
+    throw new Error('Date is invalid')
+  }
+
+  const adjustedTs = ts + timeInMs
+
+  return new Date(adjustedTs)
+}


### PR DESCRIPTION
- Use Vancouver time for fiscal year towards the end / start of year
- Fix bug where fiscal receipt can contain a slash character, messing up the paths.